### PR TITLE
Use correct npx command inside the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,21 @@
 
 This package provides a [Model Context Protocol](https://modelcontextprotocol.com/) server for integrating Linkup's web search functionality with AI models that support function calling through MCP.
 
+You can check the NPM page [here](https://www.npmjs.com/package/linkup-mcp-server).
+
 ## Installation & Usage
 
 You can run the Linkup MCP server directly using npx:
 
 ```bash
-npx -y linkup-mcp --api-key=YOUR_LINKUP_API_KEY
+npx -y linkup-mcp-server --api-key=YOUR_LINKUP_API_KEY
 ```
 
 Alternatively, you can set your API key as an environment variable:
 
 ```bash
 export LINKUP_API_KEY=YOUR_LINKUP_API_KEY
-npx -y linkup-mcp
+npx -y linkup-mcp-server
 ```
 
 # Command Line Options
@@ -36,7 +38,7 @@ To ensure compatibility with Claude, we recommend that `npx` command be accessib
   "mcpServers": {
     "linkup": {
       "command": "npx",
-      "args": ["-y", "linkup-mcp"],
+      "args": ["-y", "linkup-mcp-server"],
       "env": {
         "LINKUP_API_KEY": "YOUR_LINKUP_API_KEY"
       }
@@ -52,7 +54,7 @@ or
   "mcpServers": {
     "linkup": {
       "command": "npx",
-      "args": ["-y", "linkup-mcp", "--api-key=YOUR_LINKUP_API_KEY"]
+      "args": ["-y", "linkup-mcp-server", "--api-key=YOUR_LINKUP_API_KEY"]
     }
   }
 }
@@ -69,8 +71,8 @@ or
 Clone the repository and install dependencies:
 
 ```bash
-git clone git@github.com:LinkupPlatform/linkup-js-mcp.git
-cd linkup-js-mcp
+git clone git@github.com:LinkupPlatform/js-mcp-server.git
+cd js-mcp-server
 npm install
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkup-mcp-server",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkup-mcp-server",
-      "version": "1.0.0",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.6.1",


### PR DESCRIPTION
This pull request includes several updates to the `README.md` file to correct the package name and repository URL for the Linkup MCP server. The changes ensure that the instructions and references are consistent with the correct package name and repository.

Key changes:

* Updated the package name in the installation and usage instructions to `linkup-mcp-server` instead of `linkup-mcp`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R41) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R57)
* Modified the repository URL in the cloning instructions to `js-mcp-server` instead of `linkup-js-mcp`.
* Added a link to the NPM page for the `linkup-mcp-server` package.